### PR TITLE
docs: add central README for OctoAcme project management docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,34 @@
+```markdown
+# OctoAcme Project Management Docs
+
+Welcome to the central hub for OctoAcme’s project management processes. This README provides a concise overview of how we run projects and direct links to all process documentation maintained in this folder. Use this as the starting point for onboarding, execution, and process improvements.
+
+## Project Management Processes Summary
+
+OctoAcme follows a structured, iterative approach that guides teams from Project Initiation through Planning, Execution, Release, and Retrospective/Continuous Improvement. Key principles include customer-first delivery, iterative increments, clear ownership, and data-informed decisions. Projects rely on explicit artifacts (Project One-pager / Charter, prioritized backlog, release plans, risk register, and retrospectives) and defined roles—Project Manager (PM), Product Manager (PdM), Developers, QA/Testers, and Stakeholders.
+
+Core workflows emphasize small, testable increments and predictable delivery: backlog items use templates with acceptance criteria and estimates; a project board with Backlog → Ready → In Progress → In Review → QA → Done supports visibility; and a pull request workflow requires linked issues, CI checks, and approvals. Communication cadence centers on daily standups, weekly PM+PdM syncs, sprint demos, and regular stakeholder updates supported by weekly status and incident templates. Escalation paths and a simple runbook are used for critical incidents.
+
+Quality assurance and risk management are embedded throughout the lifecycle: unit/integration/smoke tests and CI security scans are required where appropriate; manual QA is used for feature acceptance as needed; and releases include pre-release checks, rollback plans, and post-release verification. Retrospectives are timeboxed and produce 2–3 prioritized, tracked action items to drive continuous improvement.
+
+This README is your entrypoint to the process docs. If you have changes or improvements, please propose them via the repository's process doc issue template so we can review and keep documentation current.
+
+## Documents
+
+- [Project Management Overview](octoacme-project-management-overview.md)
+- [Project Initiation Guide](octoacme-project-initiation.md)
+- [Project Planning](octoacme-project-planning.md)
+- [Execution & Tracking](octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+- [Roles & Personas](octoacme-roles-and-personas.md)
+
+## How to propose changes
+
+Use the "Add Content to Project Management Process Docs" issue template in .github/ISSUE_TEMPLATE/ to propose new or updated content. For quick edits, open a pull request that references the related issue.
+
+---
+
+Start here to understand OctoAcme's approach or to propose updates that improve our processes and documentation.
+```


### PR DESCRIPTION
Adds a new comprehensive README.md in docs/ summarizing OctoAcme's project management processes and linking to all process docs.
Closes #2